### PR TITLE
在 API 验证中增加对服务器API的验证。

### DIFF
--- a/server/components/auth/api-auth.js
+++ b/server/components/auth/api-auth.js
@@ -7,7 +7,6 @@ const generateCode = (serverName, timestamp) => {
     const hash = crypto.createHmac('sha256', secret)
         .update(`ihci${serverName}${timestamp}`)
         .digest('hex');
-    console.log(hash);
     return hash;
 };
 

--- a/server/components/auth/api-auth.js
+++ b/server/components/auth/api-auth.js
@@ -1,15 +1,50 @@
 const resProcessor = require('../../components/res-processor/res-processor')
+const crypto = require('crypto');
 
+const serverAllowed = ['calendar'];
+const generateCode = (serverName, timestamp) => {
+    const secret = 'ihci';
+    const hash = crypto.createHmac('sha256', secret)
+        .update(`ihci${serverName}${timestamp}`)
+        .digest('hex');
+    console.log(hash);
+    return hash;
+};
+
+
+/**
+ * this component is used to authorize the request
+ * req.rSession.userId: if the user is login, req.rSession.userId is not empty.
+ * req.body.authCode: request made by other servers (such as calendar) includes the authCode for authorize.
+ *      authCode rules: SHA(timestamp + server name)
+ *
+ */
 const apiAuth = (req, res, next) => {
     if(req.rSession.userId) {
         next()
+    } else if (req.body.authCode) {
+        for (let i=0;i<serverAllowed.length;i++) {
+            let server = serverAllowed[i];
+            const timestamp = Date.now() - Date.now()%60000;
+            const previousTS = Date.now() - Date.now()%60000 - 60000;
+            if (req.body.authCode === generateCode(server, timestamp) ||
+                req.body.authCode === generateCode(server, previousTS)) {
+                next();
+                return;
+            }
+        }
+        resProcessor.jsonp(req, res, {
+            state: { code: 0, msg: '请先登录' },
+            data: {}
+        });
+
+
     } else {
         resProcessor.jsonp(req, res, {
             state: { code: 0, msg: '请先登录' },
             data: {}
         });
 
-        return
     }
 }
 

--- a/server/routes/ihci-main.js
+++ b/server/routes/ihci-main.js
@@ -41,7 +41,7 @@ const routerAuthJudge = async (req, res, next) => {
     //         res.redirect('/person')
     //         return
     //     }
-    // } 
+    // }
     if(!userId) {
         res.redirect('/')
         return
@@ -83,6 +83,7 @@ const test1 = async (req, res, next) => {
     res.send('dataStr1')
 }
 
+// WARNING: 如果域名变更或者本地IP调试将会导致出错。
 const addwww = async (req, res, next) => {
     console.log(req.url)
     if(req.url.indexOf('www.')=== -1){
@@ -111,7 +112,7 @@ const mainPage = async (req, res, next) => {
         renderData: {},
     };
     htmlProcessor(req, res, next, options)
-    
+
 }
 
 const teamPage = async (req, res, next) => {


### PR DESCRIPTION
在 API 鉴权组件中增加对外部服务器的支持。
服务器的鉴权使用authCode验证：发起请求端生存autho并hash，然后由服务端验证有效性。

CC: @OoKyleoO 
addwww建议更名为redirect2www，实现内个人不建议写死域名，这样会导致更换域名或者本地运行调试死出现错误的跳转。个人建议：
if nowUrl === 'animita.cn' then redirect 'www.animita.cn‘